### PR TITLE
feat: definir redes Docker para aplicación, persistencia y monitoreo

### DIFF
--- a/networks.tf
+++ b/networks.tf
@@ -1,0 +1,17 @@
+// Capa de Aplicacion
+resource "docker_network" "app_net" {
+  name   = "app_net"
+  driver = "bridge"
+}
+
+// Capa de Persistencia
+resource "docker_network" "persistence_net" {
+  name   = "persistence_net"
+  driver = "bridge"
+}
+
+// Capa de Monitoreo
+resource "docker_network" "monitor_net" {
+  name   = "monitor_net"
+  driver = "bridge"
+}


### PR DESCRIPTION
Se agrega el archivo `networks.tf` con la definición de tres redes Docker:
- app_net (capa de aplicación)
- persistence_net (capa de persistencia)
- monitor_net (capa de monitoreo)