### PR TITLE
feat: actualizar nombre de contenedores para nginx

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,5 +3,5 @@ variable "nginx_container_count" {
 }
 
 variable "nginx_base_port" {
-  type = number
+ type = number
 }


### PR DESCRIPTION
Se actualizó la configuración de los contenedores Nginx para que el nombre incluya el workspace activo de Terraform.

### Cambios realizados
- Ajuste en `nginx.tf`: `name = "app-${terraform.workspace}-${count.index + 1}"`.
- Ahora los contenedores se crearán con nombres únicos según el workspace.