### PR TITLE
refactor: usar workspace en nombre del contenedor PostgreSQL

### DIFF
--- a/postgre.tf
+++ b/postgre.tf
@@ -4,7 +4,7 @@ resource "docker_image" "postgres" {
 
 resource "docker_container" "postgres" {
   image = docker_image.postgres.image_id
-  name  = "postgres"
+  name  = "postgres-${terraform.workspace}"
   
   networks_advanced {
     name = docker_network.persistence_net.name


### PR DESCRIPTION
- Cambiar nombre del contenedor de "postgres" a "postgres-${terraform.workspace}"
- Permite manejar múltiples entornos (dev, qa, prod) sin conflictos
- Evita colisiones de nombres entre diferentes workspaces