### PR TITLE
refactor: actualizar nombre de contenedores para incluir workspaces en nginx 

### DIFF
--- a/nginx.tf
+++ b/nginx.tf
@@ -6,7 +6,7 @@ resource "docker_image" "nginx" {
 resource "docker_container" "nginx" {
   count = var.nginx_container_count
   
-  name  = "app${count.index + 1}"
+  name  = "app-${terraform.workspace}-${count.index + 1}"
   image = docker_image.nginx.image_id
   
   networks_advanced {

--- a/variables.tf
+++ b/variables.tf
@@ -3,5 +3,5 @@ variable "nginx_container_count" {
 }
 
 variable "nginx_base_port" {
-  type = number
+ type = number
 }


### PR DESCRIPTION
### Descripción
Se actualizó la configuración de los contenedores Nginx para que el nombre incluya el workspace activo de Terraform.

### Cambios realizados
- Ajuste en `nginx.tf`: `name = "app-${terraform.workspace}-${count.index + 1}"`.
- Ahora los contenedores se crearán con nombres únicos según el workspace (`app-dev-1`, `app-qa-1`, `app-prod-1`, etc.).
